### PR TITLE
Add aquaculture monitoring skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ actions:
 | **Monitoring** | temperature-monitor, humidity-watch, power-usage |
 | **Security** | motion-detect, door-sensor, camera-patrol |
 | **Agriculture** | soil-moisture, greenhouse-climate, irrigation-control |
+| **Aquaculture** | aquaculture-monitoring, pond-health, water-quality |
 | **Industrial** | vibration-analysis, predictive-maintenance, energy-audit |
 | **Home** | elder-care, pet-monitor, plant-watering |
 | **DevOps** | server-health, log-watcher, deploy-notifier |

--- a/skills/aquaculture-monitoring/README.md
+++ b/skills/aquaculture-monitoring/README.md
@@ -1,0 +1,68 @@
+# Aquaculture Monitoring Skill
+
+This skill configures a Claw agent to monitor fish-farm water quality and raise operational alerts before conditions become unsafe.
+
+It is designed for edge devices that receive periodic readings from pond, tank, or cage sensors. The skill focuses on parameters that operators typically need to watch continuously:
+
+- dissolved oxygen
+- water temperature
+- pH
+- salinity
+- turbidity
+- ammonia
+- water level
+- sensor freshness
+
+## When To Use
+
+Use this skill for:
+
+- pond or tank health monitoring
+- shrimp, fish, or recirculating aquaculture systems
+- early warning alerts for oxygen, pH, ammonia, or temperature drift
+- local edge monitoring when internet connectivity is unreliable
+
+## Expected Events
+
+The skill expects sensor events in this general shape:
+
+```json
+{
+  "pond_id": "pond-a",
+  "timestamp": "2026-05-31T12:00:00Z",
+  "dissolved_oxygen_mg_l": 5.8,
+  "water_temperature_c": 27.5,
+  "ph": 7.4,
+  "salinity_ppt": 12.0,
+  "turbidity_ntu": 18,
+  "ammonia_mg_l": 0.05,
+  "water_level_cm": 130
+}
+```
+
+Individual deployments can rename fields through the `field_mapping` section in `skill.yaml`.
+
+## Alert Logic
+
+The skill separates warning, critical, and stale-data states.
+
+Warning alerts are intended for operator review. Critical alerts should trigger immediate notification and optional local automation, such as starting aeration or increasing water exchange.
+
+Stale sensor data is treated as a first-class risk. A pond that has stopped reporting can be more dangerous than a pond with a single borderline reading.
+
+## Actions
+
+Default actions are conservative:
+
+- log every reading
+- send operator alerts for warnings
+- escalate critical alerts to both local and cloud channels
+- optionally activate aeration when dissolved oxygen is critically low
+- mark sensors as stale when readings are too old
+
+Hardware-specific relay or pump actions are left disabled by default and should be wired by each deployment.
+
+## Tuning
+
+Thresholds in `skill.yaml` are practical defaults, not veterinary or regulatory advice. Operators should adjust them for local species, water body type, stocking density, climate, and sensor accuracy.
+

--- a/skills/aquaculture-monitoring/skill.yaml
+++ b/skills/aquaculture-monitoring/skill.yaml
@@ -1,0 +1,176 @@
+name: aquaculture-monitoring
+version: 1.0.0
+description: Monitor aquaculture water quality and alert operators on unsafe pond or tank conditions.
+agent: picclaw
+category: agriculture
+
+triggers:
+  - event: sensor.aquaculture.water_quality
+  - cron: "*/10 * * * *"
+
+field_mapping:
+  pond_id: pond_id
+  timestamp: timestamp
+  dissolved_oxygen: dissolved_oxygen_mg_l
+  water_temperature: water_temperature_c
+  ph: ph
+  salinity: salinity_ppt
+  turbidity: turbidity_ntu
+  ammonia: ammonia_mg_l
+  water_level: water_level_cm
+
+thresholds:
+  dissolved_oxygen_mg_l:
+    warning_low: 5.0
+    critical_low: 3.5
+  water_temperature_c:
+    warning_low: 20.0
+    warning_high: 31.0
+    critical_low: 16.0
+    critical_high: 35.0
+  ph:
+    warning_low: 6.8
+    warning_high: 8.5
+    critical_low: 6.2
+    critical_high: 9.0
+  salinity_ppt:
+    warning_low: 2.0
+    warning_high: 35.0
+  turbidity_ntu:
+    warning_high: 50.0
+    critical_high: 100.0
+  ammonia_mg_l:
+    warning_high: 0.05
+    critical_high: 0.2
+  water_level_cm:
+    warning_low: 80.0
+    critical_low: 50.0
+  sensor_freshness_minutes:
+    warning: 20
+    critical: 45
+
+rules:
+  - id: oxygen-critical-low
+    when: dissolved_oxygen_mg_l < thresholds.dissolved_oxygen_mg_l.critical_low
+    severity: critical
+    message: Dissolved oxygen is critically low. Start aeration and inspect pond immediately.
+    actions:
+      - log_event
+      - send_operator_alert
+      - activate_aeration_relay
+      - escalate_to_cloud
+
+  - id: oxygen-warning-low
+    when: dissolved_oxygen_mg_l < thresholds.dissolved_oxygen_mg_l.warning_low
+    severity: warning
+    message: Dissolved oxygen is below the warning threshold.
+    actions:
+      - log_event
+      - send_operator_alert
+
+  - id: temperature-out-of-range
+    when: water_temperature_c < thresholds.water_temperature_c.warning_low or water_temperature_c > thresholds.water_temperature_c.warning_high
+    severity: warning
+    message: Water temperature is outside the normal operating range.
+    actions:
+      - log_event
+      - send_operator_alert
+
+  - id: ph-critical
+    when: ph < thresholds.ph.critical_low or ph > thresholds.ph.critical_high
+    severity: critical
+    message: Water pH is critically outside the safe range.
+    actions:
+      - log_event
+      - send_operator_alert
+      - escalate_to_cloud
+
+  - id: ammonia-high
+    when: ammonia_mg_l > thresholds.ammonia_mg_l.warning_high
+    severity: warning
+    message: Ammonia is above the warning threshold.
+    actions:
+      - log_event
+      - send_operator_alert
+
+  - id: ammonia-critical
+    when: ammonia_mg_l > thresholds.ammonia_mg_l.critical_high
+    severity: critical
+    message: Ammonia is critically high. Inspect filtration, feeding, and water exchange immediately.
+    actions:
+      - log_event
+      - send_operator_alert
+      - escalate_to_cloud
+
+  - id: turbidity-high
+    when: turbidity_ntu > thresholds.turbidity_ntu.warning_high
+    severity: warning
+    message: Turbidity is elevated and may indicate algae bloom, sediment, or feed waste.
+    actions:
+      - log_event
+      - send_operator_alert
+
+  - id: water-level-low
+    when: water_level_cm < thresholds.water_level_cm.warning_low
+    severity: warning
+    message: Water level is below the warning threshold.
+    actions:
+      - log_event
+      - send_operator_alert
+
+  - id: stale-reading
+    when: minutes_since(timestamp) > thresholds.sensor_freshness_minutes.warning
+    severity: warning
+    message: Water-quality sensor data is stale.
+    actions:
+      - log_event
+      - send_operator_alert
+
+actions:
+  log_event:
+    type: local_log
+    path: /var/log/clawland/aquaculture-monitoring.log
+
+  send_operator_alert:
+    type: notification
+    channels:
+      - telegram
+      - email
+    template: "[{{ severity }}] {{ pond_id }}: {{ message }}"
+
+  activate_aeration_relay:
+    type: gpio_relay
+    enabled: false
+    relay_name: aeration
+    duration_minutes: 15
+
+  escalate_to_cloud:
+    type: webhook
+    enabled: true
+    endpoint_env: CLAWLAND_ALERT_WEBHOOK_URL
+
+outputs:
+  metrics:
+    - dissolved_oxygen_mg_l
+    - water_temperature_c
+    - ph
+    - salinity_ppt
+    - turbidity_ntu
+    - ammonia_mg_l
+    - water_level_cm
+  events:
+    - aquaculture.warning
+    - aquaculture.critical
+    - aquaculture.sensor_stale
+
+metadata:
+  domain: aquaculture
+  deployment_targets:
+    - pond
+    - tank
+    - cage
+    - recirculating-aquaculture-system
+  notes:
+    - Thresholds are defaults and should be tuned per species, climate, and sensor calibration.
+    - Relay actions are disabled by default to avoid unsafe automation without site-specific wiring.
+


### PR DESCRIPTION
## Summary

Adds an `aquaculture-monitoring` skill package for Clawland agents.

## Changes

- Adds `skills/aquaculture-monitoring/skill.yaml` with water-quality field mapping, thresholds, alert rules, and actions.
- Adds `skills/aquaculture-monitoring/README.md` with usage guidance, expected event shape, alert logic, and tuning notes.
- Lists aquaculture examples in the root skill categories table.

## Validation

- Parsed `skill.yaml` with Ruby YAML successfully.

This is intended to cover the aquaculture monitoring skill bounty requirement.